### PR TITLE
Fix issue where enhancements are not present when date picker open and a new date is entered in input

### DIFF
--- a/src/js/DatePicker.js
+++ b/src/js/DatePicker.js
@@ -16,11 +16,6 @@ class DatePicker {
          */
         this.$html = null;
         /**
-         * Calendar trigger button
-         * @type {JQuery|null}
-         */
-        this.$triggerButton = null;
-        /**
          * Date input
          * @type {JQuery|null}
          */
@@ -70,6 +65,7 @@ class DatePicker {
             let $linkedTriggerButton = this.$html.find('#' + linkedTriggerButtonId);
             let altField = $datePickerInput.attr('data-pulsar-datepicker-altfield');
             let altFormat = $datePickerInput.attr('data-pulsar-datepicker-altformat');
+            let boundEnhanceDatePicker = this.enhanceDatePicker.bind(this, $datePickerInput)
 
             if ($datePickerInput.attr('data-pulsar-datepicker-trigger') === undefined) {
                 console.warn('Datepicker: The date input must include a data-pulsar-datepicker-trigger data attribute with the value matching the ID of the trigger button');
@@ -116,6 +112,13 @@ class DatePicker {
                 // Hide the default JQUI trigger button so we can attach to our own
                 beforeShow: function (input, inst) {
                     $(inst.dpDiv).addClass('pulsar-datepicker');
+                },
+                onUpdateDatepicker: function (obj) {
+                    // Trigger enhancements on datepicker DOM update
+                    // Fixes timing issue where calendar open and
+                    // date entered in input causing a rerender of
+                    // JQUI calender that is missing enhancements
+                    boundEnhanceDatePicker($datePickerInput)
                 }
             });
 
@@ -125,7 +128,7 @@ class DatePicker {
             // Switch off autocomplete to avoid it overlapping the date picker
             $datePickerInput.attr('autocomplete', 'off');
 
-            $linkedTriggerButton.on('click', this.enhanceDatePicker.bind(this, $datePickerInput));
+            $linkedTriggerButton.on('click', () => { boundEnhanceDatePicker($datePickerInput) });
         });
 
         $html.on('click', '#ui-datepicker-div .ui-datepicker-close', () => {
@@ -138,9 +141,11 @@ class DatePicker {
      * @param {Event} event
      */
     enhanceDatePicker ($datePickerInput, event) {
-        event.preventDefault();
+        // If triggered by button, prevent the default behaviour
+        if (event instanceof $.Event) {
+            event.preventDefault();
+        }
 
-        this.$triggerButton = $(event.target);
         this.$dateInput = $datePickerInput;
         this.$dateInput.datepicker('show');
         this.$datePickerContainer = this.$html.find('#ui-datepicker-div');

--- a/src/js/DatePicker.js
+++ b/src/js/DatePicker.js
@@ -128,7 +128,7 @@ class DatePicker {
             // Switch off autocomplete to avoid it overlapping the date picker
             $datePickerInput.attr('autocomplete', 'off');
 
-            $linkedTriggerButton.on('click', () => { boundEnhanceDatePicker($datePickerInput) });
+            $linkedTriggerButton.on('click', (event) => { boundEnhanceDatePicker(event) });
         });
 
         $html.on('click', '#ui-datepicker-div .ui-datepicker-close', () => {


### PR DESCRIPTION
Alternative fix option to #24 . 

Rather than running enhancements on each keyup event we're using the JQUI Datepicker `onUpdateDatepicker` event (detects changes to the datepicker DOM - such as those changes resulting from a date being selected or typed). Needed as JQUI appears to re-render the datepicker following a manual date entry, resulting in the datepicker missing the enhancements.

Closes #23 

